### PR TITLE
chore: add packageManager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   "license": "MIT",
   "main": "dist/index.js",
   "name": "@echecs/pgn",
+  "packageManager": "pnpm@10.33.0",
   "sideEffects": false,
   "repository": {
     "type": "git",


### PR DESCRIPTION
adds packageManager to package.json — helps dependabot detect the pnpm ecosystem