### PR TITLE
release: @echecs/pgn@4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [4.0.0] - 2026-04-27
+
+### Changed
+
+- `Move` now extends `SAN` from `@echecs/san` — all SAN fields are always
+  present (no more optional `capture`, `check`, `checkmate`)
+- `piece` values changed from uppercase chars to full words (`'P'` -> `'pawn'`,
+  `'N'` -> `'knight'`, `'B'` -> `'bishop'`, `'R'` -> `'rook'`, `'Q'` ->
+  `'queen'`, `'K'` -> `'king'`)
+- `promotion` values changed from uppercase chars to full words (`'queen'`,
+  `'rook'`, `'bishop'`, `'knight'`)
+- `castling` changed from optional boolean to required boolean, with new `long`
+  boolean field replacing destination-based detection
+- `capture`, `check`, `checkmate` changed from optional to always present
+  (default `false`)
+- `to` is `undefined` for castling moves (destination square resolved
+  internally)
+
+### Added
+
+- re-exports `Piece`, `PromotionPiece`, `SAN`, `Disambiguation`, `File`, `Rank`,
+  `Square` from `@echecs/san`
+
+### Removed
+
+- `PieceChar` type (replaced by `Piece` from `@echecs/san`)
+
 ## [3.12.2] - 2026-04-09
 
 ### Changed
@@ -410,8 +437,9 @@ and this project adheres to
 - New grammar supporting the full PGN specification including RAV (recursive
   annotated variations) and NAG (numeric annotation glyphs)
 
-[unreleased]: https://github.com/mormubis/pgn/compare/v3.12.2...HEAD
-[3.12.2]: https://github.com/mormubis/pgn/compare/v3.12.1...v3.12.2
+[unreleased]: https://github.com/echecsjs/pgn/compare/v4.0.0...HEAD
+[4.0.0]: https://github.com/echecsjs/pgn/compare/v3.12.2...v4.0.0
+[3.12.2]: https://github.com/echecsjs/pgn/compare/v3.12.1...v3.12.2
 [3.12.1]: https://github.com/mormubis/pgn/compare/v3.12.0...v3.12.1
 [3.12.0]: https://github.com/mormubis/pgn/compare/v3.11.0...v3.12.0
 [3.11.0]: https://github.com/mormubis/pgn/compare/v3.10.1...v3.11.0

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ const games = parse(`
 `);
 
 console.log(games[0].moves[0]);
-// [1, { piece: 'P', to: 'e4' }, { piece: 'P', to: 'e5' }]
+// [1, { piece: 'pawn', to: 'e4', capture: false, ... }, { piece: 'pawn', to: 'e5', capture: false, ... }]
 ```
 
 ## Usage
@@ -183,16 +183,23 @@ present) as the authoritative game outcome.
 
 ### Move object
 
+`Move` extends `SAN` from [`@echecs/san`](https://github.com/echecsjs/san) — all
+SAN fields are always present.
+
 ```typescript
 {
-  piece:       PieceChar,    // always present; 'P' | 'R' | 'N' | 'B' | 'Q' | 'K'
-  to:          Square,       // destination square, e.g. "e4"
-  from?:       Disambiguation, // file "e", rank "2", or square "e2"
-  capture?:    boolean,
-  castling?:   boolean,
-  check?:      boolean,
-  checkmate?:  boolean,
-  promotion?:  PieceChar,
+  // SAN fields (always present)
+  piece:       Piece,        // 'pawn' | 'knight' | 'bishop' | 'rook' | 'queen' | 'king'
+  to:          Square | undefined, // destination square, e.g. "e4"; undefined for castling
+  from:        Disambiguation | undefined, // file "e", rank "2", or square "e2"
+  capture:     boolean,
+  castling:    boolean,
+  check:       boolean,
+  checkmate:   boolean,
+  long:        boolean,      // queenside castling
+  promotion:   PromotionPiece | undefined, // 'queen' | 'rook' | 'bishop' | 'knight'
+
+  // PGN-specific fields (optional)
   annotations?: string[],   // e.g. ["!", "$14"]
   comment?:    string,
   arrows?:     Arrow[],              // from [%cal ...] command
@@ -215,7 +222,9 @@ slots can be `undefined` — `whiteMove` when a variation begins on black's turn
 
 ```typescript
 {
-  piece: 'N', to: 'f3',
+  piece: 'knight', to: 'f3', capture: false, castling: false,
+  check: false, checkmate: false, long: false,
+  from: undefined, promotion: undefined,
   annotations: ['!', '14'],  // numeric NAGs stored without '$' prefix
   comment: 'White has a slight advantage'
 }
@@ -266,7 +275,9 @@ type Eval =
 
 ```typescript
 {
-  piece: 'P', to: 'e4',
+  piece: 'pawn', to: 'e4', capture: false, castling: false,
+  check: false, checkmate: false, long: false,
+  from: undefined, promotion: undefined,
   // comment is absent — no free text remains after stripping commands
   arrows: [
     { color: 'G', from: 'e2', to: 'e4' },
@@ -287,9 +298,11 @@ branches:
 
 ```typescript
 {
-  piece: 'B', to: 'a5',
+  piece: 'bishop', to: 'a5', capture: false, castling: false,
+  check: false, checkmate: false, long: false,
+  from: undefined, promotion: undefined,
   variants: [
-    [ [5, undefined, { piece: 'B', to: 'e7' }], [6, { piece: 'P', to: 'd4' }] ]
+    [ [5, undefined, { piece: 'bishop', to: 'e7', ... }], [6, { piece: 'pawn', to: 'd4', ... }] ]
   ]
 }
 ```
@@ -306,16 +319,18 @@ import type {
   Eval, // { type: 'cp' | 'mate', value, depth? }
   File, // 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h'
   Meta, // { [key: string]: string | undefined }
-  Move, // single parsed move object
+  Move, // single parsed move object (extends SAN)
   MoveList, // MovePair[]
   MovePair, // [number, Move | undefined, Move?]
   ParseError, // { message, offset, line, column }
   ParseOptions, // { onError?, onWarning? }
   ParseWarning, // { message, offset, line, column }
   PGN, // { meta, moves, result }
-  PieceChar, // 'P' | 'R' | 'N' | 'B' | 'Q' | 'K'
+  Piece, // 'pawn' | 'knight' | 'bishop' | 'rook' | 'queen' | 'king'
+  PromotionPiece, // 'knight' | 'bishop' | 'rook' | 'queen'
   Rank, // '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8'
   Result, // '1-0' | '0-1' | '1/2-1/2' | '?'
+  SAN, // base SAN interface from @echecs/san
   Square, // `${File}${Rank}`, e.g. "e4"
   SquareAnnotation, // { color, square }
   StringifyOptions, // { onWarning? }

--- a/package.json
+++ b/package.json
@@ -94,5 +94,5 @@
   },
   "type": "module",
   "types": "dist/index.d.ts",
-  "version": "3.12.2"
+  "version": "4.0.0"
 }


### PR DESCRIPTION
## Summary

- **breaking**: `Move` now extends `SAN` from `@echecs/san` — field names and value types changed
- `piece`/`promotion` use full words (`'pawn'`, `'knight'`, etc.) instead of uppercase chars
- `capture`, `check`, `checkmate`, `castling` are always present (no longer optional)
- new `long` boolean field for queenside castling
- `PieceChar` removed, replaced by `Piece` and `PromotionPiece` from `@echecs/san`
- changelog and README updated