### PR TITLE
fix: add @echecs/san as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "description": "Parse and stringify PGN (Portable Game Notation) chess games. Zero dependencies, strict TypeScript, no-throw parse API.",
   "devDependencies": {
-    "@echecs/san": "^3.0.0",
+    "@echecs/san": "^3.1.1",
     "@eslint/js": "^10.0.1",
     "@mliebelt/pgn-parser": "^1.4.15",
     "@types/node": "^25.5.0",
@@ -91,6 +91,9 @@
       "rollup": "^4.59.0",
       "vite": "^6.4.1"
     }
+  },
+  "peerDependencies": {
+    "@echecs/san": "^3.0.0"
   },
   "type": "module",
   "types": "dist/index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,8 @@ importers:
   .:
     devDependencies:
       '@echecs/san':
-        specifier: ^3.0.0
-        version: 3.1.0
+        specifier: ^3.1.1
+        version: 3.1.1(@echecs/position@3.1.0)
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.2.1)
@@ -127,8 +127,18 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@echecs/san@3.1.0':
-    resolution: {integrity: sha512-pZXctaeBOQV/TTWmq8Ni79yfSh+5XC4LrH0FKlzWhp9PdCdvnyqMMcPAgIMGjSlrH2lB/Su7Xf6KKJ+3dI6M8g==}
+  '@echecs/position@3.1.0':
+    resolution: {integrity: sha512-NjyPnbq4NaNfhbEtFTW61/qKLsR+BkFeus9Z/RIaHEJI7Kr0WWkjyKoU3t6FNUjFr5m+QkjV2jo6vzfElpS5hw==}
+    engines: {node: '>=20'}
+
+  '@echecs/san@3.1.1':
+    resolution: {integrity: sha512-ngby2jFagpkEjKJ6wXi6XKm+6UTDEvdXeUD6Z+O9vM5h9BMd+7V2sLP32jQxM/AnByThPKze92y7gxdLV2/0nQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@echecs/position': ^3.0.0
+
+  '@echecs/zobrist@1.0.2':
+    resolution: {integrity: sha512-X2HtxAhP8zuiE9IaTJ0uM9kccQjGR9zseXZGnIB3zJmpCYcA3TBGiAceLqrtYgyjK4dpIOH5F+0R25bOWlW3Xg==}
     engines: {node: '>=20'}
 
   '@emnapi/core@1.10.0':
@@ -1461,8 +1471,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1534,8 +1544,8 @@ packages:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
 
-  postcss@8.5.12:
-    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
+  postcss@8.5.13:
+    resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -1952,7 +1962,15 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@echecs/san@3.1.0': {}
+  '@echecs/position@3.1.0':
+    dependencies:
+      '@echecs/zobrist': 1.0.2
+
+  '@echecs/san@3.1.1(@echecs/position@3.1.0)':
+    dependencies:
+      '@echecs/position': 3.1.0
+
+  '@echecs/zobrist@1.0.2': {}
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -3119,7 +3137,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.12: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -3175,9 +3193,9 @@ snapshots:
 
   pluralize@8.0.0: {}
 
-  postcss@8.5.12:
+  postcss@8.5.13:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -3476,7 +3494,7 @@ snapshots:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.12
+      postcss: 8.5.13
       rollup: 4.60.2
       tinyglobby: 0.2.16
     optionalDependencies:


### PR DESCRIPTION
## Summary

- adds `@echecs/san` as a peerDependency (`^3.0.0`) so consumers share type identity instead of getting a bundled copy that can diverge
- bumps devDependency range to `^3.1.0`
- tsdown already externalizes peerDependencies by default — `dist/index.d.ts` now emits `import { ... } from "@echecs/san"` instead of inlining the types

closes #596