### PR TITLE
chore: align .gitignore with canonical template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,20 @@
 # Output
 /dist/
 
-# Worktrees
-/.worktrees/
-
-# Generated
-/src/grammar.cjs
-*.tsbuildinfo
-
 # Node
 /node_modules/
 
 # Tests
 coverage/
-/test.pgn
+
+# Generated
+/src/grammar.cjs
+*.tsbuildinfo
+
+# Documentation
+docs/api/*
+!docs/api/.gitkeep
+
+# Agent planning artifacts
+.superpowers/
+docs/superpowers/


### PR DESCRIPTION
aligns .gitignore to the canonical trf template plus package-specific entries