### PR TITLE
chore: add publishConfig for public access

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,9 @@
   "license": "MIT",
   "main": "dist/index.js",
   "name": "@echecs/pgn",
+  "publishConfig": {
+    "access": "public"
+  },
   "packageManager": "pnpm@10.33.0",
   "sideEffects": false,
   "repository": {


### PR DESCRIPTION
scoped packages default to restricted on npm — this ensures public access is explicit