### PR TITLE
chore: normalize types field path

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,6 @@
     "@echecs/san": "^3.0.0"
   },
   "type": "module",
-  "types": "dist/index.d.ts",
+  "types": "./dist/index.d.ts",
   "version": "4.0.0"
 }


### PR DESCRIPTION
uses relative ./dist/index.d.ts path consistently across all packages