### PR TITLE
chore: update homepage to echecs.dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "README.md",
     "CHANGELOG.md"
   ],
-  "homepage": "https://github.com/echecsjs/pgn#readme",
+  "homepage": "https://pgn.echecs.dev",
   "keywords": [
     "chess",
     "game",


### PR DESCRIPTION
points homepage to the docs site instead of the github repo