### PR TITLE
chore: align @types/node to ^25.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@echecs/san": "^3.1.1",
     "@eslint/js": "^10.0.1",
     "@mliebelt/pgn-parser": "^1.4.15",
-    "@types/node": "^25.5.0",
+    "@types/node": "^25.9.1",
     "@typescript-eslint/parser": "^8.60.0",
     "@vitest/coverage-v8": "^4.1.7",
     "@vitest/eslint-plugin": "^1.6.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ importers:
         specifier: ^1.4.15
         version: 1.4.19
       '@types/node':
-        specifier: ^25.5.0
+        specifier: ^25.9.1
         version: 25.9.1
       '@typescript-eslint/parser':
         specifier: ^8.60.0


### PR DESCRIPTION
aligns `@types/node` version with the rest of the monorepo