### PR TITLE
release: @echecs/pgn@4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [4.1.0] - 2026-05-28
+
+### Changed
+
+- Re-exported `PieceType` and `PromotionPieceType` from `@echecs/san` instead of
+  the removed `Piece` and `PromotionPiece` aliases.
+
 ## [5.0.0] - 2026-04-28
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -99,5 +99,5 @@
   },
   "type": "module",
   "types": "./dist/index.d.ts",
-  "version": "4.0.0"
+  "version": "4.1.0"
 }


### PR DESCRIPTION
- re-exported `PieceType` and `PromotionPieceType` from `@echecs/san` instead of the removed `Piece` and `PromotionPiece` aliases
- bumped `@echecs/san` dev dependency to `^3.2.0`