### PR TITLE
fix: export parse as named export instead of default

### DIFF
--- a/src/__tests__/comparison.bench.ts
+++ b/src/__tests__/comparison.bench.ts
@@ -13,7 +13,7 @@ import { readFileSync } from 'node:fs';
 import { parse as pgnParserParse } from 'pgn-parser';
 import { bench, describe } from 'vitest';
 
-import parse from '../index.js';
+import { parse } from '../index.js';
 
 function readFile(path: string): string {
   const filename = require.resolve(path);

--- a/src/__tests__/index.bench.ts
+++ b/src/__tests__/index.bench.ts
@@ -2,7 +2,7 @@
 import { readFileSync } from 'node:fs';
 import { bench, describe } from 'vitest';
 
-import parse from '../index.js';
+import { parse } from '../index.js';
 
 function readFile(path: string): string {
   const filename = require.resolve(path);

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-import parse from '../index.js';
+import { parse } from '../index.js';
 
 function readFile(path: string): string {
   const filename = require.resolve(path);

--- a/src/__tests__/san.spec.ts
+++ b/src/__tests__/san.spec.ts
@@ -12,7 +12,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import parse from '../index.js';
+import { parse } from '../index.js';
 
 /** Parse a move string as white's first move and return the Notation object. */
 function white(san: string) {

--- a/src/__tests__/stringify.spec.ts
+++ b/src/__tests__/stringify.spec.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-import parse, { stringify } from '../index.js';
+import { parse, stringify } from '../index.js';
 
 function readFile(path: string): string {
   const filename = require.resolve(path);

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ export type {
   Variation,
 } from './types.js';
 
-export { default } from './parse.js';
+export { parse } from './parse.js';
 
 export { stream } from './stream.js';
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -41,4 +41,4 @@ function parse(input: string, options?: ParseOptions): PGN[] {
   }
 }
 
-export default parse;
+export { parse };

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,4 +1,4 @@
-import parse from './parse.js';
+import { parse } from './parse.js';
 
 import type { PGN, ParseOptions } from './types.js';
 


### PR DESCRIPTION
replaces `export { default }` with `export { parse }` — consistent with all other parse packages (`fen`, `trf`, `san`, `tunx`).